### PR TITLE
Snapshot docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,16 +325,40 @@ From the official jest documentation:
 *Snapshot tests are a very useful tool whenever you want to make sure your UI does not change unexpectedly.
 A typical snapshot test case for a mobile app renders a UI component, takes a screenshot, then compares it to a reference image stored alongside the test. The test will fail if the two images do not match: either the change is unexpected, or the screenshot needs to be updated to the new version of the UI component.*
 
+You can use this plugin to improve and better control the formatting of your snapshots:
+
+* https://github.com/tjw-lint/jest-serializer-vue-tjw
+
 ```javascript
-test('snapshot test', () => {
+test('Modal renders correctly when visible: true', () => {
   const wrapper = mount(Modal, {
     propsData: {
       visible: true
     }
-  })
-  // wrapper.html() -> string of the html of our mounted component
-  expect(wrapper.html()).toMatchSnapshot()
-})
+  });
+
+  // Will store a snapshot of the entire component
+  expect(wrapper)
+    .toMatchSnapshot();
+});
+```
+
+```javascript
+test('Advanced form is shown after clicking "show more"', async () => {
+  const wrapper = mount(GenericForm);
+
+  // Target a specific element and similuate interacting with it
+  const showMore = wrapper.find('[data-test="showMore"]');
+  showMore.trigger('click');
+  
+  // Wait for the trigger event to be handled
+  await wrapper.vm.$nextTick();
+
+  // Will store a snapshot of a portion of the component containing
+  // the element that has a matching data-test attribute.
+  expect(wrapper.find('[data-test="advancedForm"]'))
+    .toMatchSnapshot();
+});
 ```
 
 ### Testing helper functions 


### PR DESCRIPTION
```
// wrapper.html() -> string of the html of our mounted component
```

This was removed because the default snapshot serializer, and the `tjw` version both handle passing in Vue components/VNodes directly. Passing in `wrapper` on its own gives the serializer more control to improve formatting the snapshots. 

Renamed the test from `'snapshot test'` to `'Modal renders correctly when visible: true'` to give a better example of how to name a snapshot test.

Added a new test to show that you can snapshot the internals of a component, since that is usually more relevant than snapshotting the entire component every time.